### PR TITLE
Fix for ESP8266 & DS1820 in parsite mode

### DIFF
--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -328,7 +328,7 @@ bool DallasTemperature::requestTemperaturesByAddress(const uint8_t* deviceAddres
     // ASYNC mode?
     if (!waitForConversion) return true;
 
-    blockTillConversionComplete(getResolution(deviceAddress), deviceAddress);
+    blockTillConversionComplete(bitResolution, deviceAddress);
 
     return true;
 


### PR DESCRIPTION
This fix is silly but without it the ESP8266 is not able to power up DS1820 in parasite mode according to datasheet