### PR TITLE
Added validFamily function

### DIFF
--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -28,6 +28,18 @@ DallasTemperature::DallasTemperature(OneWire* _oneWire)
     setOneWire(_oneWire);
 }
 
+bool DallasTemperature::validFamily(const uint8_t* deviceAddress){
+    switch (deviceAddress[0]){
+        case DS18S20MODEL:
+        case DS18B20MODEL:
+        case DS1822MODEL:
+        case DS1825MODEL:
+            return true;
+        default:
+            return false;
+    }
+}
+
 void DallasTemperature::setOneWire(OneWire* _oneWire){
 
     _wire = _oneWire;

--- a/DallasTemperature.h
+++ b/DallasTemperature.h
@@ -78,6 +78,9 @@ public:
     // returns true if address is valid
     bool validAddress(const uint8_t*);
 
+    // returns true if address is of the family of sensors the lib supports.
+    bool validFamily(const uint8_t* deviceAddress);
+
     // finds an address at a given index on the bus
     bool getAddress(uint8_t*, uint8_t);
 


### PR DESCRIPTION
This checks if a given device address belongs to the device families that the library supports.

This is useful for when you have other types of 1-wire sensors in a network, and don't want to send DS18xx specific commands
to those.