### PR TITLE
Fix bug that limits search to 1 device per wire

### DIFF
--- a/examples/oneWireSearch/oneWireSearch.ino
+++ b/examples/oneWireSearch/oneWireSearch.ino
@@ -45,7 +45,7 @@ uint8_t findDevices(int pin)
     Serial.print("\nuint8_t pin");
     Serial.print(pin, DEC);
     Serial.println("[][8] = {");
-    {
+    do {
       count++;
       Serial.println("  {");
       for (uint8_t i = 0; i < 8; i++)


### PR DESCRIPTION
The do-while loop is missing a do.

What happens without the do is a basic block, followed by while-loop with an empty body.