### PR TITLE
Fixed major bug in writeScratchPad, added code to save eeprom, fixed global resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ build
 .classpath
 .settings
 .gradle
-
+.vscode

--- a/DallasTemperature.h
+++ b/DallasTemperature.h
@@ -110,7 +110,7 @@ public:
     uint8_t getResolution(const uint8_t*);
 
     // set resolution of a device to 9, 10, 11, or 12 bits
-    bool setResolution(const uint8_t*, uint8_t);
+    bool setResolution(const uint8_t*, uint8_t, bool skipGlobalBitResolutionCalculation = false);
 
     // sets/gets the waitForConversion flag
     void setWaitForConversion(bool);


### PR DESCRIPTION
The duplicate '_wire->select(deviceAddress);' caused that nothing was written to devices at all.

Other changes include:
- prevent writing to eeprom when value in eeprom eq new value.
- setResolution(const uint8_t* deviceAddress, uint8_t newResolution) was changed to setResolution(const uint8_t* deviceAddress, uint8_t newResolution, bool skipGlobalBitResolutionCalculation). It now recalculates the global bit resolution - if required - by default, but allows for skipping.