### PR TITLE
Fixed single device conversion request bug. No way to ask a specific …

### DIFF
--- a/DallasTemperature.h
+++ b/DallasTemperature.h
@@ -146,8 +146,6 @@ public:
 
     // returns true if the bus requires parasite power
     bool isParasitePowerMode(void);
-
-    bool isConversionAvailable(const uint8_t*);
     
      // Is a conversion complete on the wire?
     bool isConversionComplete(void);
@@ -254,7 +252,7 @@ private:
 
     int16_t millisToWaitForConversion(uint8_t);
 
-    void	blockTillConversionComplete(uint8_t, const uint8_t*);
+    void	blockTillConversionComplete(uint8_t);
 
 #if REQUIRESALARMS
 


### PR DESCRIPTION
…device whether or not it is done as ANY device on the bus that is doing a conversion, will pull the bus low. This means that we can simply check whether the bus is pulled high by pull up. If so all devices are done. If we requested one, this means all one is done.
