### PR TITLE
issue #57 - removed defaultAlarmHandler(); 

### DIFF
--- a/DallasTemperature.h
+++ b/DallasTemperature.h
@@ -1,7 +1,7 @@
 #ifndef DallasTemperature_h
 #define DallasTemperature_h
 
-#define DALLASTEMPLIBVERSION "3.7.8" // To be deprecated
+#define DALLASTEMPLIBVERSION "3.7.9" // To be deprecated
 
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
@@ -168,8 +168,8 @@ public:
 	// sets the alarm handler
 	void setAlarmHandler(const AlarmHandler *);
 
-	// The default alarm handler
-	static void defaultAlarmHandler(const uint8_t*);
+	// returns true if an AlarmHandler has been set
+	bool hasAlarmHandler();
 
 #endif
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=DallasTemperature
-version=3.7.8
+version=3.7.9
 author=Miles Burton <miles@mnetcs.com>, Tim Newsome <nuisance@casualhacker.net>, Guil Barros <gfbarros@bappos.com>, Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Miles Burton <miles@mnetcs.com>
 sentence=Arduino Library for Dallas Temperature ICs


### PR DESCRIPTION
Changed under the hood implementation of AlarmHandler
+ removed defaultAlarmHandler() - was empty generated warnings.
+ added bool hasAlarmHandler() to show it has been set
+ updated constructors() - to "nullify" AlarmHandler
+ updated processAlarms() - no need to process them when there is no handler.

A better idea **with breaking interface** for the future might be to change processAlarms() to have the AlarmHandler() function as parameter.?