### PR TITLE
Fix DS18S20 off by 0.125 C

### DIFF
--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -528,7 +528,7 @@ int16_t DallasTemperature::calculateTemperature(const uint8_t* deviceAddress,
 	 */
 
 	if (deviceAddress[0] == DS18S20MODEL) {
-		fpTemperature = ((fpTemperature & 0xfff0) << 3) - 16
+		fpTemperature = ((fpTemperature & 0xfff0) << 3)
 				+ (((scratchPad[COUNT_PER_C] - scratchPad[COUNT_REMAIN]) << 7)
 						/ scratchPad[COUNT_PER_C]);
 	}


### PR DESCRIPTION
The Reading for the S version (DS18S20) are off by 0.125 degrees which originates from the "- 16".
This commit fixes this problem.