### PR TITLE
Correct first fix

### DIFF
--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -528,7 +528,7 @@ int16_t DallasTemperature::calculateTemperature(const uint8_t* deviceAddress,
 	 */
 
 	if (deviceAddress[0] == DS18S20MODEL) {
-		fpTemperature = ((fpTemperature & 0xfff0) << 3)
+		fpTemperature = ((fpTemperature & 0xfff0) << 3) - 32
 				+ (((scratchPad[COUNT_PER_C] - scratchPad[COUNT_REMAIN]) << 7)
 						/ scratchPad[COUNT_PER_C]);
 	}


### PR DESCRIPTION
Previous fix in the wrong direction "- 16" was meant to be "- 32" not "nothing". The manual states to subtract 0.25 from the temperature reading. 0.25 / 0.0078125 = 32. So this is the right value. Sorry.