### PR TITLE
fix nullptr definition for C++ < 11

### DIFF
--- a/DallasTemperature.h
+++ b/DallasTemperature.h
@@ -38,8 +38,26 @@
 #define DEVICE_DISCONNECTED_RAW -7040
 
 // For readPowerSupply on oneWire bus
-#ifndef nullptr
-#define nullptr NULL
+// definition of nullptr for C++ < 11, using official workaround:
+// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2431.pdf
+#if __cplusplus < 201103L
+const class
+{
+public:
+	template <class T>
+	operator T *() const
+	{
+		return 0;
+	}
+	template <class C, class T>
+	operator T C::*() const
+	{
+		return 0;
+	}
+
+private:
+	void operator&() const;
+} nullptr = {};
 #endif
 
 typedef uint8_t DeviceAddress[8];


### PR DESCRIPTION
Original ifndef can't work, as nullptr is not macro, but keyword.
This is proposed official workaround.