### PR TITLE
Use float for calculations between Fahrenheit and Celcius

### DIFF
--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -722,12 +722,12 @@ void DallasTemperature::setUserDataByIndex(uint8_t deviceIndex, int16_t data) {
 
 // Convert float Celsius to Fahrenheit
 float DallasTemperature::toFahrenheit(float celsius) {
-	return (celsius * 1.8) + 32;
+	return (celsius * 1.8f) + 32.0f;
 }
 
 // Convert float Fahrenheit to Celsius
 float DallasTemperature::toCelsius(float fahrenheit) {
-	return (fahrenheit - 32) * 0.555555556;
+	return (fahrenheit - 32.0f) * 0.555555556f;
 }
 
 // convert from raw to Celsius
@@ -736,7 +736,7 @@ float DallasTemperature::rawToCelsius(int16_t raw) {
 	if (raw <= DEVICE_DISCONNECTED_RAW)
 		return DEVICE_DISCONNECTED_C;
 	// C = RAW/128
-	return (float) raw * 0.0078125;
+	return (float) raw * 0.0078125f;
 
 }
 
@@ -747,7 +747,7 @@ float DallasTemperature::rawToFahrenheit(int16_t raw) {
 		return DEVICE_DISCONNECTED_F;
 	// C = RAW/128
 	// F = (C*1.8)+32 = (RAW/128*1.8)+32 = (RAW*0.0140625)+32
-	return ((float) raw * 0.0140625) + 32;
+	return ((float) raw * 0.0140625f) + 32.0f;
 
 }
 


### PR DESCRIPTION
The result of these calculations is stored in float, which in the case
of 32bit wide floats has 5 digits of accuracy. this is enough for the
purpose. Without this change, the calculations are performed promoted
and performed in double precision, which is very inefficient on some
platforms that do not have support for hardware based double floating point.