### PR TITLE
Use strict dependency to OneWire library

### DIFF
--- a/library.json
+++ b/library.json
@@ -32,7 +32,7 @@
   {
     "paulstoffregen/OneWire": "^2.3.5"
   },
-  "version": "3.9.0",
+  "version": "3.9.1",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.json
+++ b/library.json
@@ -30,9 +30,7 @@
   ],
   "dependencies":
   {
-    "name": "OneWire",
-    "authors": "Paul Stoffregen",
-    "frameworks": "arduino"
+    "paulstoffregen/OneWire": "^2.3.5"
   },
   "version": "3.9.0",
   "frameworks": "arduino",


### PR DESCRIPTION
PlatformIO 5.0 allows declaring string dependencies using semantic versioning

- https://docs.platformio.org/en/latest/core/history.html#id2

This helps to resolve issues with conflicting names and versions.