### PR TITLE
Making blockTillConversionComplete public

### DIFF
--- a/DallasTemperature.h
+++ b/DallasTemperature.h
@@ -257,6 +257,8 @@ public:
 
 #endif
 
+	void blockTillConversionComplete(uint8_t);
+
 private:
 	typedef uint8_t ScratchPad[9];
 
@@ -292,7 +294,6 @@ private:
 	// reads scratchpad and returns the raw temperature
 	int16_t calculateTemperature(const uint8_t*, uint8_t*);
 
-	void blockTillConversionComplete(uint8_t);
 
 	// Returns true if all bytes of scratchPad are '\0'
 	bool isAllZeros(const uint8_t* const scratchPad, const size_t length = 9);


### PR DESCRIPTION
We must measure from several DS18B20 at once, so we `setWaitForConversion(false)`, run the multiple `requestTemperaturesByAddress()` needed, and then use `blockTillConversionComplete` manually after the last request.