### PR TITLE
Convenience updates

### DIFF
--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -454,7 +454,7 @@ void DallasTemperature::blockTillConversionComplete(uint8_t bitResolution) {
 }
 
 // returns number of milliseconds to wait till conversion is complete (based on IC datasheet)
-int16_t DallasTemperature::millisToWaitForConversion(uint8_t bitResolution) {
+uint16_t DallasTemperature::millisToWaitForConversion(uint8_t bitResolution) {
 
 	switch (bitResolution) {
 	case 9:

--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -469,6 +469,11 @@ uint16_t DallasTemperature::millisToWaitForConversion(uint8_t bitResolution) {
 
 }
 
+// returns number of milliseconds to wait till conversion is complete (based on IC datasheet)
+uint16_t DallasTemperature::millisToWaitForConversion() {
+  return millisToWaitForConversion(bitResolution);
+}
+
 // Sends command to one device to save values from scratchpad to EEPROM by index
 // Returns true if no errors were encountered, false indicates failure
 bool DallasTemperature::saveScratchPadByIndex(uint8_t deviceIndex) {
@@ -738,6 +743,19 @@ float DallasTemperature::rawToCelsius(int16_t raw) {
 	// C = RAW/128
 	return (float) raw * 0.0078125f;
 
+}
+
+// Convert from Celsius to raw returns temperature in raw integer format.
+// The rounding error in the conversion is smaller than 0.01°C
+// where the resolution of the sensor is at best 0.0625°C (in 12 bit mode).
+// Rounding error can be verified by running:
+//  for (float t=-55.; t<125.; t+=0.01)
+//  {
+//    Serial.println( DallasTemperature::rawToCelsius(DallasTemperature::celsiusToRaw(t))-t, 4 );
+//  }
+int16_t DallasTemperature::celsiusToRaw(float celsius) {
+
+    return static_cast<uint16_t>( celsius * 128.f );
 }
 
 // convert from raw to Fahrenheit

--- a/DallasTemperature.h
+++ b/DallasTemperature.h
@@ -158,7 +158,9 @@ public:
 	// Is a conversion complete on the wire? Only applies to the first sensor on the wire.
 	bool isConversionComplete(void);
 
-  int16_t millisToWaitForConversion(uint8_t);
+  static uint16_t millisToWaitForConversion(uint8_t);
+  
+  uint16_t millisToWaitForConversion();
   
   // Sends command to one device to save values from scratchpad to EEPROM by index
   // Returns true if no errors were encountered, false indicates failure
@@ -243,6 +245,9 @@ public:
 
 	// convert from raw to Celsius
 	static float rawToCelsius(int16_t);
+
+    // convert from Celsius to raw
+	static int16_t celsiusToRaw(float);
 
 	// convert from raw to Fahrenheit
 	static float rawToFahrenheit(int16_t);


### PR DESCRIPTION
These are mostly minor additions (useful to me, might be to others as well) with the exception of commit cd2d2b6 which changes the signature of millisToWaitForConversion to return an unsigned int - it fixes a compiler warning in the common case of comparison to millis().