### PR TITLE
add Arduino-CI + prepare unit tests

### DIFF
--- a/.arduino-ci.yml
+++ b/.arduino-ci.yml
@@ -1,0 +1,11 @@
+compile:
+  # Choosing to run compilation tests on 2 different Arduino platforms
+  platforms:
+    - uno
+    - leonardo
+    - due
+    - zero
+unittest:
+  # These dependent libraries will be installed
+  libraries:
+    - "OneWire"

--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -1,0 +1,10 @@
+on: [push, pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: arduino/arduino-lint-action@v1
+        with:
+          library-manager: update
+          compliance: strict

--- a/.github/workflows/arduino_test_runner.yml
+++ b/.github/workflows/arduino_test_runner.yml
@@ -1,0 +1,13 @@
+---
+name: Arduino CI
+
+on: [push, pull_request]
+
+jobs:
+  arduino_ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Arduino-CI/action@master
+          #   Arduino-CI/action@v0.1.1

--- a/.github/workflows/jsoncheck.yml
+++ b/.github/workflows/jsoncheck.yml
@@ -1,0 +1,18 @@
+name: JSON check
+
+on:
+  push:
+    paths:
+      - '**.json'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: json-syntax-check
+        uses: limitusus/json-syntax-check@v1
+        with:
+          pattern: "\\.json$"
+

--- a/.github/workflows/jsoncheck.yml
+++ b/.github/workflows/jsoncheck.yml
@@ -1,18 +1,10 @@
-name: JSON check
-
-on:
-  push:
-    paths:
-      - '**.json'
-  pull_request:
-
+on: [push, pull_request]
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: json-syntax-check
-        uses: limitusus/json-syntax-check@v1
-        with:
-          pattern: "\\.json$"
-
+      - uses: arduino/arduino-lint-action@v1
+#       with:
+#         library-manager: update
+#         compliance: strict

--- a/.github/workflows/jsoncheck.yml
+++ b/.github/workflows/jsoncheck.yml
@@ -1,10 +1,18 @@
-on: [push, pull_request]
+name: JSON check
+
+on:
+  push:
+    paths:
+      - '**.json'
+  pull_request:
+
 jobs:
-  lint:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: arduino/arduino-lint-action@v1
-#       with:
-#         library-manager: update
-#         compliance: strict
+      - name: json-syntax-check
+        uses: limitusus/json-syntax-check@v1
+        with:
+          pattern: "\\.json$"
+

--- a/test/unit_test_001.cpp_disabled
+++ b/test/unit_test_001.cpp_disabled
@@ -1,0 +1,95 @@
+
+// DISABLED AS NOT ALL STD LIBRARIES ARE MOCKED / INCLUDEABLE
+
+
+//
+//    FILE: unit_test_001.cpp
+//  AUTHOR: Miles Burton / Rob Tillaart
+//    DATE: 2021-01-10
+// PURPOSE: unit tests for the Arduino-Temperature-Control-Library
+//          https://github.com/MilesBurton/Arduino-Temperature-Control-Library
+//          https://github.com/Arduino-CI/arduino_ci/blob/master/REFERENCE.md
+//
+
+// supported assertions
+// ----------------------------
+// assertEqual(expected, actual);               // a == b
+// assertNotEqual(unwanted, actual);            // a != b
+// assertComparativeEquivalent(expected, actual);    // abs(a - b) == 0 or (!(a > b) && !(a < b))
+// assertComparativeNotEquivalent(unwanted, actual); // abs(a - b) > 0  or ((a > b) || (a < b))
+// assertLess(upperBound, actual);              // a < b
+// assertMore(lowerBound, actual);              // a > b
+// assertLessOrEqual(upperBound, actual);       // a <= b
+// assertMoreOrEqual(lowerBound, actual);       // a >= b
+// assertTrue(actual);
+// assertFalse(actual);
+// assertNull(actual);
+
+// // special cases for floats
+// assertEqualFloat(expected, actual, epsilon);    // fabs(a - b) <= epsilon
+// assertNotEqualFloat(unwanted, actual, epsilon); // fabs(a - b) >= epsilon
+// assertInfinity(actual);                         // isinf(a)
+// assertNotInfinity(actual);                      // !isinf(a)
+// assertNAN(arg);                                 // isnan(a)
+// assertNotNAN(arg);                              // !isnan(a)
+
+#include <ArduinoUnitTests.h>
+
+
+#include "Arduino.h"
+
+/*
+
+
+// BASED UPON SIMPLE
+// 
+
+
+#include "OneWire.h"
+#include "DallasTemperature.h"
+
+// Data wire is plugged into port 2 on the Arduino
+#define ONE_WIRE_BUS 2
+
+// Setup a oneWire instance to communicate with any OneWire devices (not just Maxim/Dallas temperature ICs)
+OneWire oneWire(ONE_WIRE_BUS);
+
+// Pass our oneWire reference to Dallas Temperature. 
+DallasTemperature sensors(&oneWire);
+
+
+
+unittest_setup()
+{
+}
+
+unittest_teardown()
+{
+}
+
+
+
+unittest(test_constructor)
+{
+  fprintf(stderr, "VERSION: %s\n", DALLASTEMPLIBVERSION);
+  
+  sensors.begin();
+  sensors.requestTemperatures();
+  float tempC = sensors.getTempCByIndex(0);
+  if(tempC != DEVICE_DISCONNECTED_C) 
+  {
+    fprintf(stderr, "Temperature for the device 1 (index 0) is: ");
+    fprintf(stderr, "5f\n", tempC);
+  } 
+  else
+  {
+    fprintf(stderr, "Error: Could not read temperature data\n");
+  }
+
+  assertEqual(1, 1);  // keep unit test happy
+}
+*/
+
+unittest_main()
+
+// --------


### PR DESCRIPTION
Based upon - https://github.com/marketplace/actions/arduino_ci

**Goal**
The goal of continuous integration and unit testing is to have a set of automated actions to improve the quality and consistency of the code and its interface. To reach this goal two major steps exist

1. Automatic compilation of all examples on different platforms  **this PR**
2. Automatic unit tests  **disabled**

The automatic build of examples shows 
- the library compiles 
- the examples compile

The automatic compilation is done for (to be expanded in the future)
- uno
- leonardo
- due
- zero


**Unit Tests disabled**
The unit test is disabled by altering its extension. The reason is that the mocking / including of the complete Arduino environment is not complete yet. An issue has been raised for this and equivalent libraries - https://github.com/Arduino-CI/arduino_ci/issues/251

**Notes**
- Code of library has not changed.
- Option to add badges in the readme.md file  like below to show status of library 

![image](https://user-images.githubusercontent.com/462844/104117289-685e4700-5320-11eb-9243-7b75b18ec26c.png)
(these are just an example)
