### PR TITLE
Change strict name checking in Arduino-lint

### DIFF
--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: arduino/arduino-lint-action@v1
         with:
           library-manager: update
-          compliance: strict
+          # compliance: strict

--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -1,3 +1,6 @@
+
+name: Arduino-lint
+
 on: [push, pull_request]
 jobs:
   lint:


### PR DESCRIPTION
This solves the lint error message about the long library name in the test.

See discussion - https://github.com/arduino/arduino-lint/issues/178

This will not solve the license error message by Arduino-lint.
A separate file called LICENSE in the root of the lib is needed for that.
