### PR TITLE
Fix build-CI + add badges to readme.md

### DIFF
--- a/.arduino-ci.yml
+++ b/.arduino-ci.yml
@@ -2,9 +2,13 @@ compile:
   # Choosing to run compilation tests on 2 different Arduino platforms
   platforms:
     - uno
-    - leonardo
     - due
-    - zero
+    # - zero         # SAMD covered by M4
+    # - leonardo     # AVR covered by UNO
+    - m4
+    # - esp32        # errors on OneWire =>  util/crc16.h  vs  rom/crc.h
+    - esp8266
+    # - mega2560     # AVR covered by UNO
 unittest:
   # These dependent libraries will be installed
   libraries:

--- a/.github/workflows/arduino_test_runner.yml
+++ b/.github/workflows/arduino_test_runner.yml
@@ -4,10 +4,14 @@ name: Arduino CI
 on: [push, pull_request]
 
 jobs:
-  arduino_ci:
+  runTest:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-      - uses: Arduino-CI/action@master
-          #   Arduino-CI/action@v0.1.1
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+      - run: |
+          gem install arduino_ci
+          arduino_ci.rb

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+[![Arduino CI](https://github.com/milesburton/Arduino-Temperature-Control-Library/workflows/Arduino%20CI/badge.svg)](https://github.com/marketplace/actions/arduino_ci)
+[![Arduino-lint](https://github.com/milesburton/Arduino-Temperature-Control-Library/actions/workflows/arduino-lint.yml/badge.svg)](https://github.com/RobTillaart/AS5600/actions/workflows/arduino-lint.yml)
+[![JSON check](https://github.com/milesburton/Arduino-Temperature-Control-Library/actions/workflows/jsoncheck.yml/badge.svg)](https://github.com/RobTillaart/AS5600/actions/workflows/jsoncheck.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/milesburton/Arduino-Temperature-Control-Library/blob/master/LICENSE)
+[![GitHub release](https://img.shields.io/github/release/milesburton/Arduino-Temperature-Control-Library.svg?maxAge=3600)](https://github.com/milesburton/Arduino-Temperature-Control-Library/releases)
+
+
 # Arduino Library for Maxim Temperature Integrated Circuits
 
 ## Usage

--- a/test/unit_test_001.cpp.disabled
+++ b/test/unit_test_001.cpp.disabled
@@ -37,42 +37,70 @@
 
 
 #include "Arduino.h"
-
-/*
-
-
-// BASED UPON SIMPLE
-// 
-
-
 #include "OneWire.h"
 #include "DallasTemperature.h"
 
-// Data wire is plugged into port 2 on the Arduino
-#define ONE_WIRE_BUS 2
-
-// Setup a oneWire instance to communicate with any OneWire devices (not just Maxim/Dallas temperature ICs)
-OneWire oneWire(ONE_WIRE_BUS);
-
-// Pass our oneWire reference to Dallas Temperature. 
-DallasTemperature sensors(&oneWire);
-
+/*
+NOTE 2022-06-03: why is unit test disabled.
+There are problems with the including of util/crc16.h by Onewire.h
+Without it test can't be run.
+*/
 
 
 unittest_setup()
 {
+  fprintf(stderr, "VERSION: %s\n", DALLASTEMPLIBVERSION);
 }
 
 unittest_teardown()
 {
+  fprintf(stderr, "\n");
 }
 
 
-
-unittest(test_constructor)
+unittest(test_models)
 {
-  fprintf(stderr, "VERSION: %s\n", DALLASTEMPLIBVERSION);
-  
+  assertEqual(0x10, DS18S20MODEL);
+  assertEqual(0x28, DS18B20MODEL);
+  assertEqual(0x22, DS1822MODEL);
+  assertEqual(0x3B, DS1825MODEL);
+  assertEqual(0x42, DS28EA00MODEL);
+}
+
+
+unittest(test_error_code)
+{
+  assertEqual(-255,   DEVICE_DISCONNECTED_C);
+  assertEqual(-427,   DEVICE_DISCONNECTED_F);
+  assertEqual(-32640, DEVICE_DISCONNECTED_RAW);
+
+  assertEqual(-254, DEVICE_FAULT_OPEN_C);
+  assertEqualFloat(-425.199982, DEVICE_FAULT_OPEN_F, 0.001);
+  assertEqual(-32512, DEVICE_FAULT_OPEN_RAW);
+
+  assertEqual(-253, DEVICE_FAULT_SHORTGND_C);
+  assertEqualFloat(-423.399994, DEVICE_FAULT_SHORTGND_F, 0.001);
+  assertEqual(-32384, DEVICE_FAULT_SHORTGND_RAW);
+
+  assertEqual(-252, DEVICE_FAULT_SHORTVDD_C);
+  assertEqualFloat(-421.599976, DEVICE_FAULT_SHORTVDD_F, 0.001);
+  assertEqual( -32256, DEVICE_FAULT_SHORTVDD_RAW);
+}
+
+
+unittest(test_simple)
+{
+/*
+  // BASED UPON SIMPLE (won't run, see above)
+  // 
+  // Data wire is plugged into port 2 on the Arduino
+  #define ONE_WIRE_BUS 2
+
+  // Setup a oneWire instance to communicate with any OneWire devices (not just Maxim/Dallas temperature ICs)
+  OneWire oneWire(ONE_WIRE_BUS);
+
+  // Pass our oneWire reference to Dallas Temperature. 
+  DallasTemperature sensors(&oneWire);
   sensors.begin();
   sensors.requestTemperatures();
   float tempC = sensors.getTempCByIndex(0);
@@ -85,10 +113,10 @@ unittest(test_constructor)
   {
     fprintf(stderr, "Error: Could not read temperature data\n");
   }
+*/
 
   assertEqual(1, 1);  // keep unit test happy
 }
-*/
 
 unittest_main()
 


### PR DESCRIPTION
- add badges to readme.md to easy see the results of build-CI (e.g. for updates / PR testing)
- fix broken build CI,
  - platforms tested (AVR, SAM, SAMD, ESP2866) these compile all examples.
  - ESP32 gave problems (need to investigate)
- LINT test OK
- JSON test OK
- unit tests can not be enabled
  - build-CI environment cannot find "util/crc16.h" (need to investigate)