### PR TITLE
Perform search for setResolution linearly?

### DIFF
--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -261,9 +261,11 @@ void DallasTemperature::setResolution(uint8_t newResolution) {
 
 	bitResolution = constrain(newResolution, 9, 12);
 	DeviceAddress deviceAddress;
+	_wire->reset_search();
 	for (uint8_t i = 0; i < devices; i++) {
-		getAddress(deviceAddress, i);
-		setResolution(deviceAddress, bitResolution, true);
+		if(_wire->search(deviceAddress) && validAddress(deviceAddress)) {
+			setResolution(deviceAddress, bitResolution, true);
+		}
 	}
 }
 
@@ -325,12 +327,14 @@ bool DallasTemperature::setResolution(const uint8_t* deviceAddress,
 	if (skipGlobalBitResolutionCalculation == false) {
 		bitResolution = newResolution;
 		if (devices > 1) {
+			DeviceAddress deviceAddr;
+			_wire->reset_search();
 			for (uint8_t i = 0; i < devices; i++) {
 				if (bitResolution == 12) break;
-				DeviceAddress deviceAddr;
-				getAddress(deviceAddr, i);
-				uint8_t b = getResolution(deviceAddr);
-				if (b > bitResolution) bitResolution = b;
+				if (_wire->search(deviceAddr) && validAddress(deviceAddr)) {
+					uint8_t b = getResolution(deviceAddr);
+					if (b > bitResolution) bitResolution = b;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
As mentioned in #193 the issue stems from repeated usage of getAddress(). It doesn't seem to me to be necessary to use iterators to sort out the performance issue in the library, just a general avoidance of getAddress() outside index based functions. 

Since getAddress() appears to be used to do a bit more than iterate through addresses I added validAddress() as an additional condition, it might not be needed.

I only found two locations where this appears to happen. both are in setResolution functions. So #193 may be resolved entirely by this. General advice to users of the library may be to avoid index based functions inside loops. This might be where an "iterator" interface may be useful inside the class, such that performing functions across devices remains somewhat linear.