### PR TITLE
Handle requests using timestamps

### DIFF
--- a/DallasTemperature.h
+++ b/DallasTemperature.h
@@ -139,14 +139,23 @@ public:
 	void setCheckForConversion(bool);
 	bool getCheckForConversion(void);
 
+	struct request_t {
+		bool result;
+		unsigned long timestamp;
+
+		operator bool() {
+			return result;
+		}
+	};
+
 	// sends command for all devices on the bus to perform a temperature conversion
-	void requestTemperatures(void);
+	request_t requestTemperatures(void);
 
 	// sends command for one device to perform a temperature conversion by address
-	bool requestTemperaturesByAddress(const uint8_t*);
+	request_t requestTemperaturesByAddress(const uint8_t*);
 
 	// sends command for one device to perform a temperature conversion by index
-	bool requestTemperaturesByIndex(uint8_t);
+	request_t requestTemperaturesByIndex(uint8_t);
 
 	// returns temperature raw value (12 bit integer of 1/128 degrees C)
 	int32_t getTemp(const uint8_t*);
@@ -274,6 +283,8 @@ public:
 #endif
 
 	void blockTillConversionComplete(uint8_t);
+	void blockTillConversionComplete(uint8_t, unsigned long);
+	void blockTillConversionComplete(uint8_t, request_t);
 
 private:
 	typedef uint8_t ScratchPad[9];


### PR DESCRIPTION
Changes the return types of a few functions to pass along a timestamp to `blockTillConversionComplete`.
A few overloads are added to `blockTillConversionComplete`.

Example usage:
```
sensors.setWaitForConversion(false);
DallasTemperature::request_t request = sensors.requestTemperatures();
// do other work
sensors.blockTillConversionComplete(sensors.getResolution(), request);
// or
sensors.blockTillConversionComplete(sensors.getResolution(), request.timestamp);
```

Note: The struct isn't strictly necessary. I figured I should make each request function return the same struct to avoid confusion. `requestTemperatures()` could easily return just an `unsigned long`. I added a conversion operator to bool so that on the off chance anyone is using an older library their usage shouldn't break, I left the bool first for any binary compatibility issues for similar reasons. I'm not particularly happy with how long `DallasTemperature::request_t` is compared to `unsigned long`. I was considering `result_t` over `request_t`, but that's simple enough to change and obviously feel free to edit.

I added one new overload for the new request type which isn't strictly needed, but I figured would be nice to have / a good example of how the request struct can be used. It specifically handles the case where the request struct indicates the probe was disconnected when the request was made to avoid any unnecessary wait.