### PR TITLE
Remove 'f'?

### DIFF
--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -799,12 +799,12 @@ void DallasTemperature::setUserDataByIndex(uint8_t deviceIndex, int16_t data) {
 
 // Convert float Celsius to Fahrenheit
 float DallasTemperature::toFahrenheit(float celsius) {
-	return (celsius * 1.8f) + 32.0f;
+	return (celsius * 1.8) + 32.0;
 }
 
 // Convert float Fahrenheit to Celsius
 float DallasTemperature::toCelsius(float fahrenheit) {
-	return (fahrenheit - 32.0f) * 0.555555556f;
+	return (fahrenheit - 32.0) * 0.555555556;
 }
 
 // convert from raw to Celsius
@@ -813,7 +813,7 @@ float DallasTemperature::rawToCelsius(int32_t raw) {
 	if (raw <= DEVICE_DISCONNECTED_RAW)
 		return DEVICE_DISCONNECTED_C;
 	// C = RAW/128
-	return (float) raw * 0.0078125f;
+	return (float) raw * 0.0078125;
 
 }
 


### PR DESCRIPTION
HI! I'm working with a temperature Sensor in a lab setting. What does this 'f' do in this code? I have been unable to find its source and what impact f has on the conversion. I started down this road because we need our temperature readings to be more accurate, so I was taking a look at the code. We are using a DS18b20 and I did find the documentation of the sensor in the README file. Our error is closer to 10-15%, and it much higher than the physical sensors error stated in the documentation. Are there ways to calibrate this system with ONEWIRE and DALLASTEMP? I realize this is just a pull request and I really appreciate you taking the time to read.