### PR TITLE
patch: add error code handling of temperatures 

### DIFF
--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -1,7 +1,7 @@
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
 // License as published by the Free Software Foundation; either
-// version 2.1 of the License, or (at your option) any later version.
+// version 2.1 of the License, or (at your option) any later version. 
 
 #include "DallasTemperature.h"
 


### PR DESCRIPTION
tentative patch for handling issue #236
- adds unit types to force handling of different units with respect to each other
- implicit conversions to floats only for result types from existing functions
- basic error codes added as an enum, edit as needed

Please test that this compiles on hardware before commiting* I don't have an arduino laying around anymore.

Just looked back at the underlying code for the basic errors I added, the originals all appear to be from a bitmask, could be considerably faster to just pass along the error state from what was read. EG: take
```c
		if (scratchPad[TEMP_LSB] & 1) { // Fault Detected
			if (scratchPad[HIGH_ALARM_TEMP] & 1) {
				//Serial.println("open detected");
				r.reading.raw = DEVICE_FAULT_OPEN_RAW;
				r.error_code = DallasTemperature::device_error_code::device_fault_open;
				return r; //return DEVICE_FAULT_OPEN_RAW;
			}
			else if (scratchPad[HIGH_ALARM_TEMP] >> 1 & 1) {
				//Serial.println("short to ground detected");
				r.reading.raw = DEVICE_FAULT_SHORTGND_RAW;
				r.error_code = DallasTemperature::device_error_code::device_fault_shortgnd;
				return r;
			}
			else if (scratchPad[HIGH_ALARM_TEMP] >> 2 & 1) {
				//Serial.println("short to Vdd detected");
				r.reading.raw = DEVICE_FAULT_SHORTVDD_RAW;
				r.error_code = DallasTemperature::device_error_code::device_fault_shortvdd;
				return r;
			}
			else {
				// We don't know why there's a fault, exit with disconnect value
				r.reading.raw = DEVICE_DISCONNECTED_RAW;
				r.error_code = DallasTemperature::device_error_code::device_disconnected;
				return r;
			}
		}
```

and turn it into something like:

```c
		if (scratchPad[TEMP_LSB] & 1) { // Fault Detected
			        r.reading.raw = (scratchPad[HIGH_ALARM_TEMP] & 0x7) | 0x8; // treat 0x8 as "fault detected" or "disconnected"
				r.error_code = DallasTemperature::device_error_code::device_fault_open;
				return r;
		}
```