### PR TITLE
Remove shadowing by making use of more explicit names

### DIFF
--- a/DallasTemperature.h
+++ b/DallasTemperature.h
@@ -299,7 +299,7 @@ private:
 
 	// used to determine the delay amount needed to allow for the
 	// temperature conversion to take place
-	uint8_t bitResolution;
+	uint8_t globalBitResolution;
 
 	// used to requestTemperature with or without delay
 	bool waitForConversion;


### PR DESCRIPTION
The name `bitResolution` is used in different contexts in the library and sometimes the local name shadows the class attribute. This PR modifies the names to be more explicit and remove the `-Wshadow` warnings.