### PR TITLE
Only updates the supplied deviceAddress if a valid index is specified

### DIFF
--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -723,13 +723,18 @@ int32_t DallasTemperature::calculateTemperature(const uint8_t* deviceAddress,
 // the numeric value of DEVICE_DISCONNECTED_RAW is defined in
 // DallasTemperature.h. It is a large negative number outside the
 // operating range of the device
-int32_t DallasTemperature::getTemp(const uint8_t* deviceAddress) {
+int32_t DallasTemperature::getTemp(const uint8_t* deviceAddress, byte retryCount = 0) {
 
 	ScratchPad scratchPad;
-	if (isConnected(deviceAddress, scratchPad))
-		return calculateTemperature(deviceAddress, scratchPad);
-	return DEVICE_DISCONNECTED_RAW;
-
+	
+	byte retries = 0;
+	
+	while (retries++ <= retryCount) {
+    if (isConnected(deviceAddress, scratchPad))
+      return calculateTemperature(deviceAddress, scratchPad);
+  	}
+  
+  	return DEVICE_DISCONNECTED_RAW;
 }
 
 // returns temperature in degrees C or DEVICE_DISCONNECTED_C if the
@@ -737,8 +742,8 @@ int32_t DallasTemperature::getTemp(const uint8_t* deviceAddress) {
 // the numeric value of DEVICE_DISCONNECTED_C is defined in
 // DallasTemperature.h. It is a large negative number outside the
 // operating range of the device
-float DallasTemperature::getTempC(const uint8_t* deviceAddress) {
-	return rawToCelsius(getTemp(deviceAddress));
+float DallasTemperature::getTempC(const uint8_t* deviceAddress, byte retryCount = 0) {
+	return rawToCelsius(getTemp(deviceAddress, retryCount));
 }
 
 // returns temperature in degrees F or DEVICE_DISCONNECTED_F if the

--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -152,19 +152,19 @@ bool DallasTemperature::validAddress(const uint8_t* deviceAddress) {
 // finds an address at a given index on the bus
 // returns true if the device was found
 bool DallasTemperature::getAddress(uint8_t* deviceAddress, uint8_t index) {
+	if (index < devices) {
+		uint8_t depth = 0;
 
-	uint8_t depth = 0;
+		_wire->reset_search();
 
-	_wire->reset_search();
-
-	while (depth <= index && _wire->search(deviceAddress)) {
-		if (depth == index && validAddress(deviceAddress))
-			return true;
-		depth++;
+		while (depth <= index && _wire->search(deviceAddress)) {
+			if (depth == index && validAddress(deviceAddress))
+				return true;
+			depth++;
+		}
 	}
 
 	return false;
-
 }
 
 // attempt to determine if the device at the given address is connected to the bus

--- a/DallasTemperature.h
+++ b/DallasTemperature.h
@@ -159,10 +159,10 @@ public:
 	request_t requestTemperaturesByIndex(uint8_t);
 
 	// returns temperature raw value (12 bit integer of 1/128 degrees C)
-	int32_t getTemp(const uint8_t*);
+	int32_t getTemp(const uint8_t*, byte retryCount = 0);
 
 	// returns temperature in degrees C
-	float getTempC(const uint8_t*);
+	float getTempC(const uint8_t*, byte retryCount = 0);
 
 	// returns temperature in degrees F
 	float getTempF(const uint8_t*);


### PR DESCRIPTION
This change addresses #229.  I ran into the same problem described in that issue while using the [Multiple.ino](https://github.com/milesburton/Arduino-Temperature-Control-Library/blob/master/examples/Multiple/Multiple.ino) example.

I only had 1 sensor connected, but was confusingly getting temperature readings for both the sensors declared in the example.  I had received the "Unable to find address for Device 1" output from the Setup() method but the code used the address for my single sensor as the address for the nonexistent sensor.

Output from Multiple.ino example (with only 1 DS18B20 connected) before this change.  Notice that device address `2861640AF24BE40D `is used twice:
```
Dallas Temperature IC Control Library Demo
Locating devices...Found 1 devices.
Parasite power is: OFF
Unable to find address for Device 1
Device 0 Address: 2861640AF24BE40D
Device 1 Address: 2861640AF24BE40D
Device 0 Resolution: 12
Device 1 Resolution: 12
Requesting temperatures...DONE
Device Address: 2861640AF24BE40D Temp C: 23.50 Temp F: 74.30
Device Address: 2861640AF24BE40D Temp C: 23.50 Temp F: 74.30
```

Output from Multiple.ino example (with only 1 DS18B20 connected) after this change.  The nonexistent sensor is now given the address `0000000000000000`:
```
> Dallas Temperature IC Control Library Demo
> Locating devices...Found 1 devices.
> Parasite power is: OFF
> Unable to find address for Device 1
> Device 0 Address: 2861640AF24BE40D
> Device 1 Address: 0000000000000000
> Device 0 Resolution: 12
> Device 1 Resolution: 0
> Requesting temperatures...DONE
> Device Address: 2861640AF24BE40D Temp C: 23.56 Temp F: 74.41
> Device Address: 0000000000000000 Error: Could not read temperature data
```