### PR TITLE
Moved the header include below "Arduino.h"

### DIFF
--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -3,8 +3,6 @@
 // License as published by the Free Software Foundation; either
 // version 2.1 of the License, or (at your option) any later version.
 
-#include "DallasTemperature.h"
-
 // for Particle support
 // yield() is not a standard function, but instead wraps Particle process
 // https://community.particle.io/t/syscall-yield-operation/40708/2
@@ -19,6 +17,8 @@ extern "C" {
 #include "WConstants.h"
 }
 #endif
+
+#include "DallasTemperature.h"
 
 // OneWire commands
 #define STARTCONVO      0x44  // Tells device to take a temperature reading and put it on the scratchpad


### PR DESCRIPTION
In Arduino environment DallasTemperature.h needs Arduino.h to have been included in front of it (or the compiler complains about "size_t" not being a type). In smaller simple projects one is usually lucky to have it already included. But with a more complex setup the part
```c++
#elif ARDUINO >= 100
#include "Arduino.h"
```
becomes important.

Cheers