### PR TITLE
Revert commit cced10d

### DIFF
--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -152,19 +152,19 @@ bool DallasTemperature::validAddress(const uint8_t* deviceAddress) {
 // finds an address at a given index on the bus
 // returns true if the device was found
 bool DallasTemperature::getAddress(uint8_t* deviceAddress, uint8_t index) {
-	if (index < devices) {
-		uint8_t depth = 0;
 
-		_wire->reset_search();
+	uint8_t depth = 0;
 
-		while (depth <= index && _wire->search(deviceAddress)) {
-			if (depth == index && validAddress(deviceAddress))
-				return true;
-			depth++;
-		}
+	_wire->reset_search();
+
+	while (depth <= index && _wire->search(deviceAddress)) {
+		if (depth == index && validAddress(deviceAddress))
+			return true;
+		depth++;
 	}
 
 	return false;
+
 }
 
 // attempt to determine if the device at the given address is connected to the bus
@@ -723,18 +723,13 @@ int32_t DallasTemperature::calculateTemperature(const uint8_t* deviceAddress,
 // the numeric value of DEVICE_DISCONNECTED_RAW is defined in
 // DallasTemperature.h. It is a large negative number outside the
 // operating range of the device
-int32_t DallasTemperature::getTemp(const uint8_t* deviceAddress, byte retryCount = 0) {
+int32_t DallasTemperature::getTemp(const uint8_t* deviceAddress) {
 
 	ScratchPad scratchPad;
-	
-	byte retries = 0;
-	
-	while (retries++ <= retryCount) {
-    if (isConnected(deviceAddress, scratchPad))
-      return calculateTemperature(deviceAddress, scratchPad);
-  	}
-  
-  	return DEVICE_DISCONNECTED_RAW;
+	if (isConnected(deviceAddress, scratchPad))
+		return calculateTemperature(deviceAddress, scratchPad);
+	return DEVICE_DISCONNECTED_RAW;
+
 }
 
 // returns temperature in degrees C or DEVICE_DISCONNECTED_C if the
@@ -742,8 +737,8 @@ int32_t DallasTemperature::getTemp(const uint8_t* deviceAddress, byte retryCount
 // the numeric value of DEVICE_DISCONNECTED_C is defined in
 // DallasTemperature.h. It is a large negative number outside the
 // operating range of the device
-float DallasTemperature::getTempC(const uint8_t* deviceAddress, byte retryCount = 0) {
-	return rawToCelsius(getTemp(deviceAddress, retryCount));
+float DallasTemperature::getTempC(const uint8_t* deviceAddress) {
+	return rawToCelsius(getTemp(deviceAddress));
 }
 
 // returns temperature in degrees F or DEVICE_DISCONNECTED_F if the

--- a/DallasTemperature.h
+++ b/DallasTemperature.h
@@ -159,10 +159,10 @@ public:
 	request_t requestTemperaturesByIndex(uint8_t);
 
 	// returns temperature raw value (12 bit integer of 1/128 degrees C)
-	int32_t getTemp(const uint8_t*, byte retryCount = 0);
+	int32_t getTemp(const uint8_t*);
 
 	// returns temperature in degrees C
-	float getTempC(const uint8_t*, byte retryCount = 0);
+	float getTempC(const uint8_t*);
 
 	// returns temperature in degrees F
 	float getTempF(const uint8_t*);


### PR DESCRIPTION
Reverting commit cced10dc92d7a219e7935a9009b64a1d87147e0d as a temporary solution.
The previous commit cced10dc92d7a219e7935a9009b64a1d87147e0d causes failure of compilation.