### PR TITLE
Fix/ds1820 support accidentally removed

### DIFF
--- a/DallasTemperature.h
+++ b/DallasTemperature.h
@@ -1,7 +1,7 @@
 #ifndef DallasTemperature_h
 #define DallasTemperature_h
 
-#define DALLASTEMPLIBVERSION "4.0.1"
+#define DALLASTEMPLIBVERSION "4.0.2"
 
 // Configuration
 #ifndef REQUIRESNEW

--- a/examples/Simple/Simple.ino
+++ b/examples/Simple/Simple.ino
@@ -34,7 +34,7 @@ void loop(void)
   Serial.print("Requesting temperatures...");
   sensors.requestTemperatures(); // Send the command to get temperatures
   Serial.println("DONE");
-  delay(5000);
+  delay(1500);
   // After we got the temperatures, we can print them here.
   // We use the function ByIndex, and as an example get the temperature from the first sensor only.
   float tempC = sensors.getTempCByIndex(0);

--- a/examples/Simple/Simple.ino
+++ b/examples/Simple/Simple.ino
@@ -34,6 +34,7 @@ void loop(void)
   Serial.print("Requesting temperatures...");
   sensors.requestTemperatures(); // Send the command to get temperatures
   Serial.println("DONE");
+  delay(5000);
   // After we got the temperatures, we can print them here.
   // We use the function ByIndex, and as an example get the temperature from the first sensor only.
   float tempC = sensors.getTempCByIndex(0);

--- a/examples/Single/Single.ino
+++ b/examples/Single/Single.ino
@@ -105,6 +105,7 @@ void loop(void)
   Serial.print("Requesting temperatures...");
   sensors.requestTemperatures(); // Send the command to get temperatures
   Serial.println("DONE");
+  delay(5000);
 
   // It responds almost immediately. Let's print out the data
   printTemperature(insideThermometer); // Use a simple function to print out the data

--- a/examples/Single/Single.ino
+++ b/examples/Single/Single.ino
@@ -105,7 +105,7 @@ void loop(void)
   Serial.print("Requesting temperatures...");
   sensors.requestTemperatures(); // Send the command to get temperatures
   Serial.println("DONE");
-  delay(5000);
+  delay(1500);
 
   // It responds almost immediately. Let's print out the data
   printTemperature(insideThermometer); // Use a simple function to print out the data

--- a/examples/WaitForConversion/WaitForConversion.ino
+++ b/examples/WaitForConversion/WaitForConversion.ino
@@ -62,5 +62,5 @@ void loop(void)
   Serial.println(sensors.getTempCByIndex(0));
   Serial.println("\n\n\n\n");
 
-  delay(5000);
+  delay(1500);
 }

--- a/library.json
+++ b/library.json
@@ -32,7 +32,7 @@
   {
     "paulstoffregen/OneWire": "^2.3.5"
   },
-  "version": "4.0.1",
+  "version": "4.0.2",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=DallasTemperature
-version=4.0.1
+version=4.0.2
 author=Miles Burton <mail@milesburton.com>, Tim Newsome <nuisance@casualhacker.net>, Guil Barros <gfbarros@bappos.com>, Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Miles Burton <mail@milesburton.com>
 sentence=Arduino library for Dallas/Maxim temperature ICs


### PR DESCRIPTION
fix: Restore DS1820 which was removed from 4.0.1

feat: added delay to two examples to avoid it 'spinning' (which is a problem in parasite mode)

feat: bumped version to 4.0.2