### PR TITLE
Add optional addressBook output to begin() to capture discovered ROM addresses

### DIFF
--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -83,7 +83,7 @@ void DallasTemperature::setPullupPin(uint8_t _pullupPin) {
     deactivateExternalPullup();
 }
 
-void DallasTemperature::begin(void) {
+void DallasTemperature::begin(uint8_t* addressBook, uint8_t maxDeviceCount) {
     DeviceAddress deviceAddress;
     
     for (uint8_t retry = 0; retry < MAX_INITIALIZATION_RETRIES; retry++) {
@@ -95,6 +95,14 @@ void DallasTemperature::begin(void) {
         
         while (_wire->search(deviceAddress)) {
             if (validAddress(deviceAddress)) {
+                // Optionally capture the ROM discovered during enumeration into the
+                // caller-provided address book, so callers don't have to re-discover
+                // the same devices with getAddress()/search() afterwards — a second
+                // search pass that can fail intermittently on long or marginal buses.
+                if (addressBook && devices < maxDeviceCount) {
+                    memcpy(addressBook + (size_t)devices * sizeof(DeviceAddress),
+                           deviceAddress, sizeof(DeviceAddress));
+                }
                 devices++;
                 
                 if (validFamily(deviceAddress)) {

--- a/DallasTemperature.h
+++ b/DallasTemperature.h
@@ -77,7 +77,7 @@ public:
     // Setup & Configuration
     void setOneWire(OneWire*);
     void setPullupPin(uint8_t);
-    void begin(void);
+    void begin(uint8_t* addressBook = nullptr, uint8_t maxDeviceCount = 0);
     bool verifyDeviceCount(void);
 
     // Device Information


### PR DESCRIPTION
## Motivation
`begin()` already enumerates the bus (it searches and counts devices), but the discovered ROM addresses are dropped — they live only in a local variable. Callers that need the addresses must call `getAddress(addr, index)` afterwards, which runs a **second** SearchROM pass. On long or electrically marginal 1-Wire buses that second pass can intermittently fail (returns a zero / CRC-invalid ROM) even though `begin()`'s own search just succeeded — so a device that was counted can't be addressed.

## Change
Add two optional, defaulted parameters:

```cpp
void begin(uint8_t* addressBook = nullptr, uint8_t maxDeviceCount = 0);
```

When `addressBook` is provided, each valid ROM found during enumeration is copied into it (in discovery order, up to `maxDeviceCount`). This lets the caller reuse the addresses captured by the search that already ran, instead of re-discovering them with a second, less reliable search pass.

## Backward compatibility
Fully backward compatible — with no arguments `begin()` behaves exactly as before (nothing is written). No change to any existing call site or behavior.

## Example
```cpp
DeviceAddress book[4];
sensors.begin(&book[0][0], 4);            // addresses captured during enumeration
uint8_t n = sensors.getDeviceCount();
float t = sensors.getTempC(book[0]);      // read by stored address, no re-search
```
