### PR TITLE
Fix: implement missing saveScratchPadByIndex/recallScratchPadByIndex

### DIFF
--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -237,6 +237,18 @@ void DallasTemperature::writeScratchPad(const uint8_t* deviceAddress, const uint
     }
 }
 
+bool DallasTemperature::saveScratchPadByIndex(uint8_t deviceIndex) {
+    DeviceAddress deviceAddress;
+    if (!getAddress(deviceAddress, deviceIndex)) return false;
+    return saveScratchPad(deviceAddress);
+}
+
+bool DallasTemperature::recallScratchPadByIndex(uint8_t deviceIndex) {
+    DeviceAddress deviceAddress;
+    if (!getAddress(deviceAddress, deviceIndex)) return false;
+    return recallScratchPad(deviceAddress);
+}
+
 bool DallasTemperature::saveScratchPad(const uint8_t* deviceAddress) {
     if (_wire->reset() == 0) return false;
     


### PR DESCRIPTION
## Problem

`DallasTemperature.h` declares `saveScratchPadByIndex(uint8_t)` and `recallScratchPadByIndex(uint8_t)`, and both are referenced in the `SaveRecallScratchPad` example, but their implementations are missing from `DallasTemperature.cpp`. They appear to have been dropped during the race-condition refactor merged in #264 (the header declarations, keywords.txt entries, and example comments survived the refactor; the two `.cpp` bodies did not).

Any sketch that calls either method now compiles fine but fails at **link time**:

```
undefined reference to `DallasTemperature::saveScratchPadByIndex(unsigned char)'
undefined reference to `DallasTemperature::recallScratchPadByIndex(unsigned char)'
```

## Fix

Restore the two thin wrapper functions (same logic as before the refactor): resolve the device index to its address via `getAddress()`, then delegate to the existing `saveScratchPad()` / `recallScratchPad()` address-based overloads.

```cpp
bool DallasTemperature::saveScratchPadByIndex(uint8_t deviceIndex) {
    DeviceAddress deviceAddress;
    if (!getAddress(deviceAddress, deviceIndex)) return false;
    return saveScratchPad(deviceAddress);
}

bool DallasTemperature::recallScratchPadByIndex(uint8_t deviceIndex) {
    DeviceAddress deviceAddress;
    if (!getAddress(deviceAddress, deviceIndex)) return false;
    return recallScratchPad(deviceAddress);
}
```

The change is purely additive — no other lines in the file are touched, and no header changes are needed since the declarations are already correct.

## Testing

Built a small host-side harness (stub `Arduino.h`/`OneWire.h` + a `DallasTemperature` instance with a mocked single-device bus) and confirmed:
- Current `master` (unmodified): compiles, fails to **link** with the undefined-reference errors above.
- With this patch: compiles, links, and runs; `saveScratchPadByIndex(0)` / `recallScratchPadByIndex(0)` both return `true` for a valid index and `false` for an out-of-range index (matching `getAddress()`'s failure propagation), with no change to any other existing behavior (`getResolution()`, `isParasitePowerMode()`, etc. all unaffected).