### PR TITLE
Fix DS18S20 broadcast conversion wait

### DIFF
--- a/DallasTemperature.cpp
+++ b/DallasTemperature.cpp
@@ -318,12 +318,15 @@ float DallasTemperature::getTempFByIndex(uint8_t index) {
 }
 
 void DallasTemperature::setResolution(uint8_t newResolution) {
-    bitResolution = constrain(newResolution, 9, 12);
+    newResolution = constrain(newResolution, 9, 12);
+    bitResolution = newResolution;
     DeviceAddress deviceAddress;
     _wire->reset_search();
     for (uint8_t i = 0; i < devices; i++) {
         if (_wire->search(deviceAddress) && validAddress(deviceAddress)) {
-            setResolution(deviceAddress, bitResolution, true);
+            setResolution(deviceAddress, newResolution, true);
+            // DS18S20 is fixed at 9-bit but needs the 12-bit conversion delay.
+            if (deviceAddress[0] == DS18S20MODEL) bitResolution = 12;
         }
     }
 }


### PR DESCRIPTION
## Summary

- keep the requested resolution separate while configuring devices
- retain the 750 ms broadcast conversion wait when a DS18S20 is present
- preserve requested 9/10/11-bit settings for configurable sensors regardless of search order

## Problem

A DS18S20 has a fixed 9-bit temperature register, but its maximum conversion time is 750 ms. The library intentionally returns 12 from the address-based `getResolution()` as a conversion-time carrier for this reason (see #1, #4, and #174).

`setResolution(uint8_t)` currently overwrites the global `bitResolution` with the requested value and asks each address-based setter to skip global recalculation. After `setResolution(9)`, a broadcast `requestTemperatures()` therefore waits 94 ms even when a DS18S20 is on the bus. Address-based requests still wait 750 ms, so the two paths disagree.

The change keeps the caller's requested value for configurable devices while restoring the global wait carrier to 12 when the scan encounters a DS18S20.

## Validation

- Baseline host bus harness compiled the current `DallasTemperature.cpp` and reproduced global resolution 9 plus a 94 ms broadcast delay after `setResolution(9)` on a DS18S20 bus.
- The fixed source passed the same harness under GCC 13 with ASan/UBSan for a DS18S20-only bus, DS18B20 at 9/10/11/12 bits, and mixed buses in both enumeration orders.
- The same regression suite passed with MinGW GCC 8.
- `DallasTemperature.cpp` compiled for `atmega328p` with AVR GCC 7.3, `-Os -Wall -Wextra -Werror`; RAM usage was unchanged.

Not tested on a physical mixed-sensor bus.